### PR TITLE
feat: add Chrome extension for speaking YouTube subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# Speak-Subtitles-Youtube
+# Speak Subtitles YouTube
+
+Chrome extension that reads YouTube subtitles aloud using Google Cloud Text‑to‑Speech.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,51 @@
+import { loadSettings, saveSettings } from './storage.js';
+import { synthesize } from './tts.js';
+
+chrome.runtime.onInstalled.addListener(async () => {
+  const settings = await loadSettings();
+  if (settings.enabled === undefined) {
+    await saveSettings({ enabled: false });
+  }
+});
+
+chrome.action.onClicked.addListener(async (tab) => {
+  const settings = await loadSettings();
+  const enabled = !settings.enabled;
+  await saveSettings({ enabled });
+  if (tab.id) {
+    chrome.tabs.sendMessage(tab.id, { type: 'enabled', enabled });
+  }
+});
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'getSettings') {
+    loadSettings().then((s) => sendResponse(s));
+    return true;
+  }
+  if (msg.type === 'speak') {
+    loadSettings().then((settings) => {
+      synthesize(msg.text, settings, msg.speechRate).then((audioContent) => {
+        sendResponse({ audioContent });
+      });
+    });
+    return true;
+  }
+  if (msg.type === 'translate') {
+    loadSettings().then(async (settings) => {
+      const text = await translateText(msg.text, msg.source, settings.language, settings.apiKey);
+      sendResponse({ text });
+    });
+    return true;
+  }
+});
+
+async function translateText(text, source, target, apiKey) {
+  if (source === target) return text;
+  const res = await fetch(`https://translation.googleapis.com/language/translate/v2?key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: text, source, target, format: 'text' })
+  });
+  const data = await res.json();
+  return data.data?.translations?.[0]?.translatedText || text;
+}

--- a/content.js
+++ b/content.js
@@ -1,0 +1,111 @@
+let settings = null;
+let enabled = false;
+let queue = [];
+let processing = false;
+const seen = new Set();
+
+async function init() {
+  settings = await sendMessage({ type: 'getSettings' });
+  enabled = settings.enabled;
+  if (enabled) attach();
+}
+
+function attach() {
+  const video = document.querySelector('video');
+  if (!video) return;
+  for (const track of video.textTracks) {
+    track.mode = 'hidden';
+    track.addEventListener('cuechange', () => {
+      for (const cue of track.activeCues) {
+        const key = `${cue.startTime}-${cue.endTime}-${cue.text}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          queue.push({ text: cue.text, start: cue.startTime, end: cue.endTime, language: track.language });
+          processQueue();
+        }
+      }
+    });
+  }
+}
+
+async function processQueue() {
+  if (processing || !enabled) return;
+  processing = true;
+  while (queue.length && enabled) {
+    const item = queue.shift();
+    let text = item.text;
+    if (settings.translate && item.language !== settings.language) {
+      const res = await sendMessage({ type: 'translate', text, source: item.language });
+      text = res.text;
+    }
+    await speak(text, item.end - item.start);
+  }
+  processing = false;
+}
+
+async function speak(text, subtitleDuration) {
+  let speechRate = settings.speechRate;
+  const ctx = new (window.AudioContext || window.webkitAudioContext)();
+  let audio = await getAudio(text, speechRate);
+  let buffer = await decodeAudio(ctx, audio);
+  let audioDuration = buffer.duration;
+
+  if (audioDuration > subtitleDuration) {
+    while (audioDuration > subtitleDuration && speechRate > settings.minRate) {
+      speechRate = Math.max(settings.minRate, speechRate - 0.1);
+      audio = await getAudio(text, speechRate);
+      buffer = await decodeAudio(ctx, audio);
+      audioDuration = buffer.duration;
+    }
+    if (audioDuration > subtitleDuration) {
+      const video = document.querySelector('video');
+      video.playbackRate = Math.max(0.5, video.playbackRate - 0.1);
+    }
+  } else if (audioDuration < subtitleDuration) {
+    while (audioDuration < subtitleDuration && speechRate < settings.maxRate) {
+      speechRate = Math.min(settings.maxRate, speechRate + 0.1);
+      audio = await getAudio(text, speechRate);
+      buffer = await decodeAudio(ctx, audio);
+      audioDuration = buffer.duration;
+    }
+    if (audioDuration < subtitleDuration) {
+      const video = document.querySelector('video');
+      video.playbackRate = Math.min(2, video.playbackRate + 0.1);
+    }
+  }
+
+  const source = ctx.createBufferSource();
+  const gain = ctx.createGain();
+  gain.gain.value = settings.volume;
+  source.buffer = buffer;
+  source.connect(gain).connect(ctx.destination);
+  source.start();
+  await new Promise((resolve) => (source.onended = resolve));
+}
+
+function getAudio(text, speechRate) {
+  return sendMessage({ type: 'speak', text, speechRate }).then((r) => r.audioContent);
+}
+
+function decodeAudio(ctx, audioContent) {
+  const bytes = Uint8Array.from(atob(audioContent), (c) => c.charCodeAt(0));
+  return ctx.decodeAudioData(bytes.buffer);
+}
+
+function sendMessage(msg) {
+  return new Promise((resolve) => chrome.runtime.sendMessage(msg, resolve));
+}
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync' && changes.enabled) {
+    enabled = changes.enabled.newValue;
+    if (enabled) {
+      attach();
+      processQueue();
+    } else {
+      queue = [];
+    }
+  }
+});
+
+init();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Speak Subtitles",
+  "version": "1.0",
+  "description": "Read YouTube subtitles using Google TTS",
+  "permissions": ["storage", "scripting", "activeTab"],
+  "host_permissions": ["https://*.googleapis.com/*"],
+  "action": {
+    "default_title": "Speak Subtitles"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "options_page": "popup.html",
+  "content_scripts": [
+    {
+      "matches": ["https://www.youtube.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Speak Subtitles Settings</title>
+</head>
+<body>
+  <div>
+    <label>Google API Key <input id="apiKey" type="text"></label>
+  </div>
+  <div>
+    <label>Language <select id="language">
+      <option value="vi-VN">vi-VN</option>
+      <option value="en-US">en-US</option>
+      <option value="ja-JP">ja-JP</option>
+    </select></label>
+  </div>
+  <div>
+    <label><input type="checkbox" id="translate"> Translate subtitle if language mismatch</label>
+  </div>
+  <div>
+    <label>Voice <select id="voice">
+      <option value="vi-VN-Standard-A">vi-VN-Standard-A</option>
+      <option value="vi-VN-Standard-B">vi-VN-Standard-B</option>
+      <option value="en-US-Standard-C">en-US-Standard-C</option>
+    </select></label>
+  </div>
+  <div>
+    <label>Pitch <input id="pitch" type="range" min="-20" max="20" step="1"></label>
+    <span id="pitchVal"></span>
+  </div>
+  <div>
+    <label>Volume <input id="volume" type="range" min="0" max="2" step="0.1"></label>
+    <span id="volumeVal"></span>
+  </div>
+  <div>
+    <label>Speech Rate <input id="speechRate" type="range" min="0.5" max="2" step="0.1"></label>
+    <span id="rateVal"></span>
+  </div>
+  <div>
+    <label>Min Rate <input id="minRate" type="number" step="0.1"></label>
+  </div>
+  <div>
+    <label>Max Rate <input id="maxRate" type="number" step="0.1"></label>
+  </div>
+  <button id="save">Save</button>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,43 @@
+import { loadSettings, saveSettings } from './storage.js';
+
+const q = (id) => document.getElementById(id);
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const settings = await loadSettings();
+  q('apiKey').value = settings.apiKey;
+  q('language').value = settings.language;
+  q('translate').checked = settings.translate;
+  q('voice').value = settings.voice;
+  q('pitch').value = settings.pitch;
+  q('volume').value = settings.volume;
+  q('speechRate').value = settings.speechRate;
+  q('minRate').value = settings.minRate;
+  q('maxRate').value = settings.maxRate;
+  updateLabels();
+
+  ['pitch', 'volume', 'speechRate'].forEach((id) => {
+    q(id).addEventListener('input', updateLabels);
+  });
+
+  q('save').addEventListener('click', async () => {
+    const newSettings = {
+      apiKey: q('apiKey').value,
+      language: q('language').value,
+      translate: q('translate').checked,
+      voice: q('voice').value,
+      pitch: parseFloat(q('pitch').value),
+      volume: parseFloat(q('volume').value),
+      speechRate: parseFloat(q('speechRate').value),
+      minRate: parseFloat(q('minRate').value),
+      maxRate: parseFloat(q('maxRate').value)
+    };
+    await saveSettings(newSettings);
+    window.close();
+  });
+});
+
+function updateLabels() {
+  q('pitchVal').textContent = q('pitch').value;
+  q('volumeVal').textContent = q('volume').value;
+  q('rateVal').textContent = q('speechRate').value;
+}

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,20 @@
+const DEFAULTS = {
+  apiKey: '',
+  language: 'vi-VN',
+  translate: false,
+  voice: 'vi-VN-Standard-A',
+  pitch: 0,
+  volume: 1,
+  speechRate: 1,
+  minRate: 0.8,
+  maxRate: 1.2,
+  enabled: false
+};
+
+export function loadSettings() {
+  return new Promise((resolve) => chrome.storage.sync.get(DEFAULTS, resolve));
+}
+
+export function saveSettings(settings) {
+  return new Promise((resolve) => chrome.storage.sync.set(settings, resolve));
+}

--- a/tts.js
+++ b/tts.js
@@ -1,0 +1,19 @@
+export async function synthesize(text, settings, speechRate) {
+  const body = {
+    input: { text },
+    voice: { languageCode: settings.language, name: settings.voice },
+    audioConfig: {
+      audioEncoding: 'MP3',
+      speakingRate: speechRate,
+      pitch: settings.pitch,
+      volumeGainDb: (settings.volume - 1) * 16
+    }
+  };
+  const res = await fetch(`https://texttospeech.googleapis.com/v1/text:synthesize?key=${settings.apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  const data = await res.json();
+  return data.audioContent;
+}


### PR DESCRIPTION
## Summary
- implement Manifest V3 extension scaffolding for YouTube subtitles
- add settings UI with Google TTS controls stored in chrome.storage
- stream YouTube captions through Google TTS with timing synchronization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d1be718c832eb3b8c578d1bdc933